### PR TITLE
Update report.sh

### DIFF
--- a/report.sh
+++ b/report.sh
@@ -215,14 +215,27 @@ for pool in $pools; do
     scrubTime="N/A"
     statusOutput="$(zpool status "$pool")"
     if [ "$(echo "$statusOutput" | grep "scan" | awk '{print $2}')" = "scrub" ]; then
+        multiDay="$(echo "$statusOutput" | grep "scan" | grep -c "days")"
         scrubRepBytes="$(echo "$statusOutput" | grep "scan" | awk '{gsub(/B/,"",$4); print $4}')"
-        scrubErrors="$(echo "$statusOutput" | grep "scan" | awk '{print $8}')"
+        if [ "$multiDay" -ge 1 ] ; then
+          scrubErrors="$(echo "$statusOutput" | grep "scan" | awk '{print $10}')"
+        else
+          scrubErrors="$(echo "$statusOutput" | grep "scan" | awk '{print $8}')"
+        fi
         # Convert time/datestamp format presented by zpool status, compare to current date, calculate scrub age
-        scrubDate="$(echo "$statusOutput" | grep "scan" | awk '{print $15"-"$12"-"$13"_"$14}')"
+        if [ "$multiDay" -ge 1 ] ; then
+          scrubDate="$(echo "$statusOutput" | grep "scan" | awk '{print $17"-"$14"-"$15"_"$16}')"
+        else
+          scrubDate="$(echo "$statusOutput" | grep "scan" | awk '{print $15"-"$12"-"$13"_"$14}')"
+        fi
         scrubTS="$(date -j -f "%Y-%b-%e_%H:%M:%S" "$scrubDate" "+%s")"
         currentTS="$(date "+%s")"
         scrubAge=$((((currentTS - scrubTS) + 43200) / 86400))
-        scrubTime="$(echo "$statusOutput" | grep "scan" | awk '{print $6}')"
+        if [ "$multiDay" -ge 1 ] ; then
+          scrubTime="$(echo "$statusOutput" | grep "scan" | awk '{print $6" "$7" "$8}')"
+        else
+          scrubTime="$(echo "$statusOutput" | grep "scan" | awk '{print $6}')"
+        fi
     fi
     # Check if scrub is in progress
     if [ "$(echo "$statusOutput"| grep "scan" | awk '{print $4}')" = "progress" ]; then


### PR DESCRIPTION
This provides a correction for scrubs lasting over 24 hours.  Without it you get errors similar to:

Failed conversion of ``3-on-Wed_Feb'' using format ``%Y-%b-%e_%H:%M:%S'' 

and the time/date in the scrub charts is incorrectly reported as an error.

Example of a sub 24 hours scrub:
scan: scrub repaired 0B in 00:01:22 with 0 errors on Mon Feb  1 00:01:25 2021

Example of a over 24 hour scrub:
scan: scrub repaired 0B in 1 days 02:21:46 with 0 errors on Wed Feb  3 02:21:50 2021

The change was tested on TrueNas Core release 12.2-RELEASE-p2